### PR TITLE
RX State Machine HEADER_PROCESSING to BIT_FRAME_SYNC

### DIFF
--- a/DSP_API/SmartSDR_Interface/utils.c
+++ b/DSP_API/SmartSDR_Interface/utils.c
@@ -86,6 +86,7 @@ float tsfSubtract(struct timespec time1, struct timespec time2)
     return result;
 }
 
+
 //! get time since a certain time in microseconds
 uint32 usSince(struct timespec time)
 {
@@ -93,6 +94,14 @@ uint32 usSince(struct timespec time)
     clock_gettime(CLOCK_MONOTONIC, &delay);
     uint32 diff_us = (uint32)(tsfSubtract(delay, time) * 1000.0);
     return diff_us;
+}
+
+uint32 msSince(struct timespec time)
+{
+    struct timespec delay;
+    clock_gettime(CLOCK_MONOTONIC, &delay);
+    uint32 diff_ms = (uint32)(tsSubtract(delay, time));
+    return diff_ms;
 }
 
 uint32 getIP(char* text)

--- a/DSP_API/SmartSDR_Interface/utils.h
+++ b/DSP_API/SmartSDR_Interface/utils.h
@@ -40,6 +40,7 @@ void output(const char *fmt,...);
 void tsAdd(struct timespec* time1, struct timespec time2);
 float tsfSubtract(struct timespec time1, struct timespec time2);
 uint32 usSince(struct timespec time);
+uint32 msSince(struct timespec time);
 uint32 getIP(char* text);
 void lock_malloc_init(void);
 void* safe_malloc(size_t size);

--- a/DSP_API/ThumbDV/dstar.c
+++ b/DSP_API/ThumbDV/dstar.c
@@ -951,15 +951,20 @@ BOOL dstar_rxStateMachine( DSTAR_MACHINE machine, BOOL in_bit, unsigned char * a
 
                 dstar_updateStatus( machine, machine->slice, STATUS_RX );
 
+                machine->rx_state = VOICE_FRAME;
+                machine->bit_count = 0;
+                machine->frame_count = 0;
+
 
             } else {
                 output( ANSI_RED "P_FCS Does Not Match!\n" ANSI_WHITE );
+
+                machine->rx_state = BIT_FRAME_SYNC;
+                machine->bit_count = 0;
             }
 
             /* STATE CHANGE */
-            machine->rx_state = VOICE_FRAME;
-            machine->bit_count = 0;
-            machine->frame_count = 0;
+
         }
 
         break;

--- a/DSP_API/ThumbDV/thumbDV.c
+++ b/DSP_API/ThumbDV/thumbDV.c
@@ -529,14 +529,16 @@ int thumbDV_processSerial( FT_HANDLE handle )
         _thumbDVEncodedList_LinkTail( desc );
     } else if ( packet_type == AMBE3000_SPEECH_PKT_TYPE ) {
     	//output("Response Length %d \n", respLen);
-        desc = hal_BufferRequest( respLen, sizeof( unsigned char ) );
-        memcpy( desc->buf_ptr, buffer, respLen );
-        //thumbDV_dump("SPEECH Packet", buffer, respLen);
-        /* Speech data */
-        _thumbDVDecodedList_LinkTail( desc );
-        //memcpy(buffer,0,AMBE3000_HEADER_LEN);
+    	desc = hal_BufferRequest( respLen, sizeof( unsigned char ) );
+    	memcpy( desc->buf_ptr, buffer, respLen );
+    	//thumbDV_dump("SPEECH Packet", buffer, respLen);
 
-    } else {
+   		/* Speech data */
+   		_thumbDVDecodedList_LinkTail( desc );
+    	}
+
+        //memcpy(buffer,0,AMBE3000_HEADER_LEN);
+    else {
         output( ANSI_RED "Unrecognized packet type 0x%02X ", packet_type );
         return 1;
 
@@ -545,6 +547,8 @@ int thumbDV_processSerial( FT_HANDLE handle )
 
     return 0;
 }
+
+
 
 int thumbDV_decode( FT_HANDLE handle, unsigned char * packet_in, short * speech_out, uint8 bytes_in_packet) {
 
@@ -619,7 +623,6 @@ int thumbDV_decode( FT_HANDLE handle, unsigned char * packet_in, short * speech_
         /* Do nothing for now */
     	//if ( samples_returned != 160 ) output( "Rate Mismatch expected %d got %d\n", 160, samples_returned );
     }
-    //output(" in %d, out: %d \n", in, out);
     return samples_returned;
 }
 
@@ -676,6 +679,8 @@ int thumbDV_encode( FT_HANDLE handle, short * speech_in, unsigned char * packet_
 
     if ( handle != NULL )
         thumbDV_writeSerial( handle, packet, length + AMBE3000_HEADER_LEN );
+
+    thumbDV_processSerial(handle);
 
     int32 samples_returned = 0;
     BufferDescriptor desc = _thumbDVEncodedList_UnlinkHead();
@@ -750,30 +755,43 @@ static void _connectSerial( FT_HANDLE * ftHandle )
     unsigned char read_cfg[5] = {0x61, 0x00, 0x01, 0x00, 0x37};
     unsigned char dstar_mode[17] = {0x61, 0x00, 0x0D, 0x00, 0x0A, 0x01, 0x30, 0x07, 0x63, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x48};
 
-    thumbDV_writeSerial( *ftHandle, get_prodID, 5 );
+//    thumbDV_writeSerial( *ftHandle, get_prodID, 5 );
+//    //thumbDV_processSerial(*ftHandle);
+
     thumbDV_writeSerial( *ftHandle, get_version, 5 );
+    //thumbDV_processSerial(*ftHandle);
+
     thumbDV_writeSerial( *ftHandle, read_cfg, 5 );
+    //thumbDV_processSerial(*ftHandle);
+
     thumbDV_writeSerial( *ftHandle, dstar_mode, 17 );
+    thumbDV_processSerial(*ftHandle);
+    //thumbDV_processSerial(*ftHandle);
+
+    //delay(100);
 
 ////    /* Init */
     unsigned char pkt_init[6] = { 0x61, 0x00, 0x02, 0x00, 0x0B, 0x07 };
     thumbDV_writeSerial( *ftHandle, pkt_init, 6 );
+    //thumbDV_processSerial(*ftHandle);
 
     /* PKT GAIN - set to 0dB */
     unsigned char pkt_gain[7] = { 0x61, 0x00, 0x03, 0x00, 0x4B, 0x00, 0x00 };
     thumbDV_writeSerial( *ftHandle, pkt_gain, 7 );
+    //thumbDV_processSerial(*ftHandle);
 
     /* Companding off so it uses 16bit linear */
     unsigned char pkt_compand[6] = { 0x61, 0x00, 0x02, 0x00, 0x32, 0x00 };
     thumbDV_writeSerial( *ftHandle, pkt_compand, 6 );
+    //thumbDV_processSerial(*ftHandle);
 
     unsigned char test_coded[15] =  {0x61, 0x00 , 0x0B , 0x01 , 0x01 , 0x48 , 0x5E , 0x83 , 0x12 , 0x3B , 0x98 , 0x79 , 0xDE , 0x13 , 0x90};
-
     thumbDV_writeSerial( *ftHandle, test_coded, 15 );
+    //thumbDV_processSerial(*ftHandle);
+
 
     unsigned char pkt_fmt[7] = {0x61, 0x00, 0x3, 0x00, 0x15, 0x00, 0x00};
     thumbDV_writeSerial( *ftHandle, pkt_fmt, 7 );
-
     thumbDV_processSerial(*ftHandle);
 
 }
@@ -831,7 +849,7 @@ static void * _thumbDV_readThread( void * param )
         else if ( rx_bytes >= AMBE3000_HEADER_LEN )
         {
         	//output("RX Bytes: %d \n",rx_bytes);
-//            ret = thumbDV_processSerial( handle );
+            //ret = thumbDV_processSerial( handle );
 //            output("Decoded count in init: %d \n",_decoded_count);
 
         }

--- a/DSP_API/ThumbDV/thumbDV.c
+++ b/DSP_API/ThumbDV/thumbDV.c
@@ -436,11 +436,9 @@ int thumbDV_processSerial( FT_HANDLE handle )
 {
     unsigned char buffer[BUFFER_LENGTH];
     unsigned int respLen;
-    uint32 offset = 0;
+    //uint32 offset = 0;
 
     unsigned char packet_type;
-
-    unsigned char packet_length;
 
     FT_STATUS status = FT_OK;
     DWORD rx_bytes = 0;
@@ -480,30 +478,30 @@ int thumbDV_processSerial( FT_HANDLE handle )
         return 1;
     }
 
-    offset = 0U;
+    //offset = 0U;
 
     respLen = buffer[1U] * 256U + buffer[2U];
     //output("Length: %d \n", respLen);
 
-    us_slept = 0;
-    do
-    {
-        status = FT_GetStatus(handle, &rx_bytes, &tx_bytes, &event_word);
-
-        if ( rx_bytes >= respLen )
-            break;
-
-        usleep(1000);
-
-        us_slept += 1000 ;
-
-        if ( us_slept > max_us_sleep )
-        {
-            output("TimeOut\n");
-            return 1;
-        }
-
-    } while (rx_bytes < respLen && status == FT_OK);
+//    us_slept = 0;
+//    do
+//    {
+//        status = FT_GetStatus(handle, &rx_bytes, &tx_bytes, &event_word);
+//
+//        if ( rx_bytes >= respLen )
+//            break;
+//
+//        usleep(1000);
+//
+//        us_slept += 1000 ;
+//
+//        if ( us_slept > max_us_sleep )
+//        {
+//            output("TimeOut\n");
+//            return 1;
+//        }
+//
+//    } while (rx_bytes < respLen && status == FT_OK);
 
     status = FT_Read(handle, buffer + AMBE3000_HEADER_LEN , respLen, &rx_bytes);
 
@@ -516,7 +514,6 @@ int thumbDV_processSerial( FT_HANDLE handle )
 
     BufferDescriptor desc = NULL;
     packet_type = buffer[3U];
-    packet_length = buffer[1] * 256U + buffer[2]; // packet length
 
     //output("buffer [3] = %d \n", packet_type);
 

--- a/DSP_API/ThumbDV/thumbDV.c
+++ b/DSP_API/ThumbDV/thumbDV.c
@@ -344,6 +344,7 @@ FT_HANDLE thumbDV_openSerial( FT_DEVICE_LIST_INFO_NODE device )
     //struct termios tty;
     FT_HANDLE handle = NULL;
     FT_STATUS status = FT_OK;
+    UCHAR latency = 5;
 
     output("Trying to open serial port %s \n", device.SerialNumber);
 
@@ -418,6 +419,7 @@ FT_HANDLE thumbDV_openSerial( FT_DEVICE_LIST_INFO_NODE device )
 
     FT_SetDataCharacteristics(handle, FT_BITS_8, FT_STOP_BITS_1, FT_PARITY_NONE);
     FT_SetFlowControl(handle, FT_FLOW_NONE, 0, 0);
+    FT_SetLatencyTimer(handle, latency);
 
 
     if ( _check_serial( handle ) != 0 ) {

--- a/DSP_API/include/ftd2xx.h
+++ b/DSP_API/include/ftd2xx.h
@@ -155,7 +155,7 @@ enum {
 // Stop Bits
 //
 
-#define FT_STOP_BITS_1		(UCHAR) 0
+#define FT_STOP_BITS_1		(UCHAR) 1
 #define FT_STOP_BITS_2		(UCHAR) 2
 
 //

--- a/DSP_API/include/ftd2xx.h
+++ b/DSP_API/include/ftd2xx.h
@@ -155,7 +155,7 @@ enum {
 // Stop Bits
 //
 
-#define FT_STOP_BITS_1		(UCHAR) 1
+#define FT_STOP_BITS_1		(UCHAR) 0
 #define FT_STOP_BITS_2		(UCHAR) 2
 
 //


### PR DESCRIPTION
The header processing stage always switched to the VOICE_FRAME stage. This caused garbage to be loaded into decode buffers. This fix changes the logic to only switche from HEADER_PROCESS stage to VOICE_FRAME stage if there is a P_FCS match, otherwise goes back to the BIT_FRAME_SYNC stage.